### PR TITLE
Implemented partial support for Idrac7

### DIFF
--- a/bin/moob
+++ b/bin/moob
@@ -87,23 +87,21 @@ begin
     lom.authenticate
     Moob.inform "Authenticated on #{h}."
 
-    begin
-      options[:actions].each do |action|
-        action = action.to_sym
-        Moob.inform "Trying to perform #{action} on #{h}..."
-        case action
-        when :jnlp
-          Moob.start_jnlp lom
-        else
-          res = lom.send action
-          puts res if res
-        end
-        Moob.inform "Performed #{action} on #{h}."
+    options[:actions].each do |action|
+      action = action.to_sym
+      Moob.inform "Trying to perform #{action} on #{h}..."
+      case action
+      when :jnlp
+        Moob.start_jnlp lom
+      else
+        res = lom.send action
+        puts res if res
       end
-    ensure
-      lom.logout
-      Moob.inform "Logged out of #{h}."
+      Moob.inform "Performed #{action} on #{h}."
     end
+
+    lom.logout
+    Moob.inform "Logged out of #{h}."
   end
   puts 'There might be a delay before Java Web Start shows up...' if options[:action] == :jnlp
 

--- a/lib/moob.rb
+++ b/lib/moob.rb
@@ -1,5 +1,5 @@
 module Moob
-  VERSION = [0,3,5,1]
+  VERSION = [0,3,4]
 
   class ResponseError < Exception
     def initialize response

--- a/lib/moob/idrac7.rb
+++ b/lib/moob/idrac7.rb
@@ -23,6 +23,7 @@ class Idrac7 < BaseLom
     super hostname, options
     @username ||= 'root'
     @password ||= 'calvin'
+    @index = nil
   end
 
   def authenticate
@@ -43,7 +44,7 @@ class Idrac7 < BaseLom
 
     auth.body =~ /<forwardUrl>([^<]+)<\/forwardUrl>/
 
-    raise "Cannot find the authenticated index url after auth" unless $&
+    raise 'Cannot find the authenticated index url after auth' unless $&
 
     @indexurl = $1
     @authhash = @indexurl.split('?')[1]


### PR DESCRIPTION
- Version bump from '6' to '7' to get detection working.
- Idrac7 uses the ST2 header to authenticate XHR requests.
  This is only supplied inside of a generated snippet of javascript and is fished
  out in 'authenticate'.
- Added an ensure to assert that logout is invoked in case of any action failing.
  This is important in Idrac since they allow a limited amount of sessions to be
  active at the same time.
- Initial request is done against login.html in contrast to start.html since start.html
  contains a silly Javascript redirect.

Note: Work was based of Ramon's progress so far
