### PR TITLE
Added ensure clause to logout after actions.

### DIFF
--- a/bin/moob
+++ b/bin/moob
@@ -87,21 +87,26 @@ begin
     lom.authenticate
     Moob.inform "Authenticated on #{h}."
 
-    options[:actions].each do |action|
-      action = action.to_sym
-      Moob.inform "Trying to perform #{action} on #{h}..."
-      case action
-      when :jnlp
-        Moob.start_jnlp lom
-      else
-        res = lom.send action
-        puts res if res
-      end
-      Moob.inform "Performed #{action} on #{h}."
-    end
+    begin
+      options[:actions].each do |action|
+        action = action.to_sym
 
-    lom.logout
-    Moob.inform "Logged out of #{h}."
+        Moob.inform "Trying to perform #{action} on #{h}..."
+
+        case action
+        when :jnlp
+          Moob.start_jnlp lom
+        else
+          res = lom.send action
+          puts res if res
+        end
+
+        Moob.inform "Performed #{action} on #{h}."
+      end
+    ensure
+      lom.logout
+      Moob.inform "Logged out of #{h}."
+    end
   end
   puts 'There might be a delay before Java Web Start shows up...' if options[:action] == :jnlp
 


### PR DESCRIPTION
- Added clause to ensure that logout is invoked even if an exception is thrown
  in the lom handler. This could otherwise result in 'zombie' sessions
  (idrac6/7) which prevents subsequent users from logging in for a while.
