### PR TITLE
[idrac] add enable_ipmi, tweak error message

### DIFF
--- a/lib/moob/idrac6.rb
+++ b/lib/moob/idrac6.rb
@@ -17,6 +17,7 @@ class Idrac6 < BaseLom
     v6DHCPEnabled v6DHCPServers v6DNS1 v6DNS2
     v6SiteLocal v6SiteLocal3 v6SiteLocal4 v6SiteLocal5 v6SiteLocal6 v6SiteLocal7 v6SiteLocal8
     v6SiteLocal9 v6SiteLocal10 v6SiteLocal11 v6SiteLocal12 v6SiteLocal13 v6SiteLocal14 v6SiteLocal15
+    ipmiLAN ipmiMinPriv ipmiKey
   ]
 
   def initialize hostname, options = {}
@@ -61,7 +62,7 @@ class Idrac6 < BaseLom
     raise ResponseError.new idx unless idx.status == 200
 
     idx.body =~ /var DnsName += +"([^"]+)"/
-    raise "Couldn't find the DNS name" unless $&
+    raise "Couldn't find the DNS name -- is the iDRAC running firmware 1.50 or higher?" unless $&
     dns_name = $1
 
     idx.body =~ /var sysNameStr += +"([^"]+)"/
@@ -149,5 +150,13 @@ class Idrac6 < BaseLom
       end
     end]
   end
+
+  action :enable_ipmi, 'Enable IPMI over LAN (on LOM port)'
+  def enable_ipmi
+    req = @session.post 'data?set=ipmiLAN:1', {}
+    raise ResponseError.new req unless req.status == 200
+    return nil
+  end
+
 end
 end

--- a/lib/moob/idrac7.rb
+++ b/lib/moob/idrac7.rb
@@ -17,6 +17,7 @@ class Idrac7 < BaseLom
     v6DHCPEnabled v6DHCPServers v6DNS1 v6DNS2
     v6SiteLocal v6SiteLocal3 v6SiteLocal4 v6SiteLocal5 v6SiteLocal6 v6SiteLocal7 v6SiteLocal8
     v6SiteLocal9 v6SiteLocal10 v6SiteLocal11 v6SiteLocal12 v6SiteLocal13 v6SiteLocal14 v6SiteLocal15
+    ipmiLAN ipmiMinPriv ipmiKey
   ]
 
   def initialize hostname, options = {}
@@ -169,5 +170,13 @@ class Idrac7 < BaseLom
       end
     end]
   end
+
+  action :enable_ipmi, 'Enable IPMI over LAN (on LOM port)'
+  def enable_ipmi
+    req = @session.post 'data?set=ipmiLAN:1', {}
+    raise ResponseError.new req unless req.status == 200
+    return nil
+  end
+
 end
 end


### PR DESCRIPTION
minimal ipmi configuration support: enable_ipmi action to enable ipmi over LAN support

be more descriptive when jnlp fails on iDRAC6 for old firmware
