### PR TITLE
add dell idrac8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Presentation
 
 Both the device and feature lists are quite limited as its development has mostly been driven by immediate needs at Spotify. Similarly, tests are only performed on the firmware versions we have at hand.
 
-We currently have an inconsistent set of features for Dell iDrac6, American Megatrends, Sun and IBM devices. Patches and requests are welcome and we will do our best to make it useful to all.
+We currently have an inconsistent set of features for Dell iDrac6/iDrac7/iDrac8, American Megatrends, Sun and IBM devices. Patches and requests are welcome and we will do our best to make it useful to all.
 
 Installation
 ------------

--- a/lib/moob.rb
+++ b/lib/moob.rb
@@ -16,6 +16,7 @@ module Moob
   autoload :BaseLom,    'moob/baselom.rb'
   autoload :Idrac6,     'moob/idrac6.rb'
   autoload :Idrac7,     'moob/idrac7.rb'
+  autoload :Idrac8,     'moob/idrac8.rb'
   autoload :Pec,        'moob/pec.rb'
   autoload :Megatrends, 'moob/megatrends.rb'
   autoload :SunILom,    'moob/sunilom.rb'
@@ -25,6 +26,7 @@ module Moob
   TYPES = {
     :idrac6     => Idrac6,
     :idrac7     => Idrac7,
+    :idrac8     => Idrac8,
     :pec        => Pec,
     :megatrends => Megatrends,
     :sun        => SunILom,
@@ -32,7 +34,7 @@ module Moob
     :supermicro => Supermicro
   }
 
-  AUTODETECT_ORDER = [ :idrac7, :idrac6, :pec, :supermicro, :megatrends, :sun, :ibm ]
+  AUTODETECT_ORDER = [ :idrac8, :idrac7, :idrac6, :pec, :supermicro, :megatrends, :sun, :ibm ]
 
   def self.lom type, hostname, options = {}
     case type

--- a/lib/moob/idrac8.rb
+++ b/lib/moob/idrac8.rb
@@ -1,0 +1,253 @@
+require 'zlib'
+require 'stringio'
+
+module Moob
+
+class Idrac8 < BaseLom
+  @name = 'Dell iDrac 8'
+
+
+  INFO_FIELDS = %w[
+    biosVer svcTag expSvcCode hostName
+    osName osVersion sysDesc sysRev datetime initCountdown presentCountdown
+    fwVersion fwUpdated LCCfwVersion
+    firstBootDevice vmBootOnce
+    racName hwVersionmacAddr recoveryAction
+    NicEtherMac1  NicEtherMac2  NicEtherMac3  NicEtherMac4
+    NiciSCSIMac1  NiciSCSIMac2  NiciSCSIMac3  NiciSCSIMac4
+    NicEtherVMac1 NicEtherVMac2 NicEtherVMac3 NicEtherVMac4
+    v4Enabled v4IPAddr v4Gateway v4NetMask
+    v6Enabled v6Addr   v6Gateway v6Prefix v6LinkLocal
+    v4DHCPEnabled v4DHCPServers v4DNS1 v4DNS2
+    v6DHCPEnabled v6DHCPServers v6DNS1 v6DNS2
+    v6SiteLocal v6SiteLocal3 v6SiteLocal4 v6SiteLocal5 v6SiteLocal6 v6SiteLocal7 v6SiteLocal8
+    v6SiteLocal9 v6SiteLocal10 v6SiteLocal11 v6SiteLocal12 v6SiteLocal13 v6SiteLocal14 v6SiteLocal15
+    ipmiLAN ipmiMinPriv ipmiKey hostname
+  ]
+
+  def initialize hostname, options = {}
+    super hostname, options
+    @username ||= 'root'
+    @password ||= 'calvin'
+    @index = nil
+
+    @skiplogout = false
+
+    @session.headers['Accept'] = 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'
+    @session.headers['Accept-Language'] = 'en-US,en;q=0.8,sv;q=0.6'
+    # idrac8 responds with a 404 if the request is sent for html is sent without encoding headers
+    @session.headers['Accept-Encoding'] = 'gzip,deflate,sdch'
+  end
+
+  def authenticate
+    @session.handle_cookies nil
+
+    login = @session.get 'login.html'
+
+    raise ResponseError.new login unless login.status == 200
+
+    auth = @session.post 'data/login', "user=#{@username}&password=#{@password}"
+
+    raise ResponseError.new auth unless auth.status == 200
+
+    auth.body =~ /<authResult>([^<]+)<\/authResult>/
+
+    raise 'Cannot find auth result' unless $&
+    raise "Auth failed with: \"#{auth.body}\"" unless $1 == "0"
+
+    auth.body =~ /<forwardUrl>([^<]+)<\/forwardUrl>/
+
+    raise 'Cannot find the authenticated index url after auth' unless $&
+
+    @indexurl = $1
+
+    if @indexurl =~ /defaultCred/
+      @indexurl.gsub!(/defaultCred/,'index')
+      Moob.warn "iDRAC recommends you should change the default credentials!"
+    end
+
+    Moob.inform "Requesting indexurl of #{@indexurl}"
+
+    # someone decided it was a good idea to include a ST2 token in every XHR
+    # request. We need it for a lot of our features.
+    @authhash = @indexurl.split('?')[1]
+    @authhash =~ /ST2=([0-9a-f]+)/
+    @st2 = $1
+
+    if @st2.nil?
+        Moob.inform 'Trying to parse ST2 token from HTML page'
+
+        @index = @session.get @indexurl
+        @index.body =~ /var TOKEN_VALUE = "([0-9a-f]+)";/
+        raise ResponseError.new @index unless @index.status == 200
+        @st2 = $1
+    end
+
+    @session.headers['ST2'] = @st2
+
+    return self
+  end
+
+  def logout
+    if @skiplogout
+      Moob.inform 'Skipping logout...'
+    else
+      out = @session.get 'data/logout'
+      raise ResponseError.new out unless out.status == 200
+    end
+    return self
+  end
+
+  def decompress_response response
+    gz_reader = Zlib::GzipReader.new(StringIO.new(response))
+    gz_reader.read
+  end
+
+  def detect
+    begin
+      home = @session.get 'login.html'
+      # patron doesn't decompress the body automatically
+      response = decompress_response home.body
+      response =~ /(Integrated Dell Remote Access Controller 8)|(iDRAC8)/
+    rescue Exception => e
+      false
+    end
+  end
+
+  action :jnlp, 'Remote control'
+
+  def jnlp
+    # Request system name and hostname from data end-point
+    req = get_infos ['sysDesc' ,'hostname']
+
+    # eg escaped "idrac-A1BCD2E, PowerEdge R610, User:root"
+    title = CGI::escape "#{req['hostname']}, #{req['sysDesc']}, User:#{@username}"
+
+    viewer = @session.get "viewer.jnlp(#{@hostname}@0@#{title}@#{Time.now.to_i * 1000}@#{@authhash})"
+    raise ResponseError.new viewer unless viewer.status == 200
+
+    return viewer.body
+  end
+
+  def power_control action
+    req = @session.post "data?set=pwState:#{action}", {}
+    raise ResponseError.new req unless req.status == 200
+    return nil
+  end
+
+  def boot_on level
+    req = @session.post "data?set=vmBootOnce:1,firstBootDevice:#{level}", {}
+    raise ResponseError.new req unless req.status == 200
+    return nil
+  end
+
+  [
+    [0, :poff,   'Power Off System'],
+    [1, :pon,    'Power On System'],
+    [2, :pcycle,   'Power Cycle System (cold boot)'],
+    [3, :preset,   'Reset System (warm boot)'],
+    [4, :nmi,    'NMI (Non-Masking Interrupt)'],
+    [5, :shutdown, 'Graceful Shutdown']
+  ].each do |code, name, desc|
+    action name, desc
+    class_eval %{def #{name}; power_control #{code}; end}
+  end
+
+  [
+    [0,  :bnone,    'Do not change the next boot'],
+    [1,  :bpxe,     'Boot on PXE once'],
+    [6,  :bbios,    'Boot on BIOS setup once'],
+    [15, :blfloppy, 'Boot on Local Floppy/Primary Removable Media once'],
+    [5,  :blcd,     'Boot on Local CD/DVD once'],
+    [2,  :blhd,     'Boot on Hard Drive once'],
+    [9,  :biscsi,   'Boot on NIC BEV iSCSI once'],
+    [7,  :bvfloppy, 'Boot on Virtual Floppy once'],
+    [8,  :bvcd,     'Boot on Virtual CD/DVD/ISO once'],
+    [16, :blsd,     'Boot on Local SD Card once'],
+    [17, :bvbios,   'Boot on BIOS Boot Manager once'],
+    [18, :bvlc,    'Boot on Life Cycle Controller once']
+  ].each do |code, name, desc|
+    action name, desc
+    class_eval %{def #{name}; boot_on #{code}; end}
+  end
+
+  action :pstatus, 'Power status'
+  def pstatus
+    case get_infos(['pwState'])['pwState']
+    when '0'
+      return :off
+    when '1'
+      return :on
+    else
+      return nil
+    end
+  end
+
+  action :infos, 'Get system information'
+  def infos
+    return JSON.pretty_generate get_infos INFO_FIELDS
+  end
+
+  def get_infos keys
+    Moob.inform "Requesting data?get=#{keys.join(',')}"
+    infos = @session.post "data?get=#{keys.join(',')}", {}
+
+    raise ResponseError.new infos unless infos.status == 200
+    raise "The status isn't OK" unless infos.body =~ /<status>ok<\/status>/
+
+    return Hash[keys.collect do |k|
+      if infos.body =~ /<#{k}>(.*?)<\/#{k}>/
+        [k, $1]
+      else
+        [k, nil]
+      end
+    end]
+  end
+
+  action :set_params, 'Set iDRAC parameters'
+  def set_params
+    unless @params
+      raise "Params are not set!"
+    end
+    drac_set_params @params
+  end
+
+  action :enable_ipmi, 'Enable IPMI over LAN (on LOM port)'
+  def enable_ipmi
+    drac_set_params({ 'ipmiLAN' => 1 })
+  end
+
+  def drac_set_params params
+    params.each do |p,v|
+      req = @session.post "data?set=#{p}:#{v}", {}
+      raise ResponseError.new req unless req.status == 200
+    end
+    return nil
+  end
+
+  action :show_console_preview, 'Display iDRAC console screenshot'
+  action :save_console_preview, 'Save iDRAC console screenshot'
+
+  def fetch_console_preview
+    imgfile = Tempfile.new('console_preview')
+
+    refreshreq = @session.get "data?get=consolepreview[auto%20#{Time.now.utc.to_i}]", {}
+
+    raise ResponseError.new req unless refreshreq.status == 200
+
+    req = @session.get_file "capconsole/scapture0.png?#{Time.now.utc.to_i}", imgfile.path
+
+    raise ResponseError.new req unless req.status == 200
+    raise UnexpectedContentError.new req unless req.headers['Content-type'] =~ /image\//
+
+    return imgfile, req.headers
+  end
+
+  action :lomreset, 'Reset LOM'
+  def lomreset
+    @skiplogout = true
+    drac_set_params({ 'iDracReset' => 1 })
+  end
+
+end
+end

--- a/lib/moob/version.rb
+++ b/lib/moob/version.rb
@@ -1,3 +1,3 @@
 module Moob
-  VERSION = [0,3,16]
+  VERSION = [0,4,0]
 end


### PR DESCRIPTION
The Dell iDrac8 is shipped with the new 13th generation platform

There a couple notable changes:
  * requests need to be sent with an accept-encoding otherwise the drac responds with a 404
  * patron doesn't decompress responses automatically
   * https://github.com/toland/patron/issues/64

@nferch 