### PR TITLE
Make default password warning verbose-only

### DIFF
--- a/lib/moob/idrac7.rb
+++ b/lib/moob/idrac7.rb
@@ -56,7 +56,7 @@ class Idrac7 < BaseLom
 
     if @indexurl =~ /defaultCred/
       @indexurl.gsub!(/defaultCred/,'index')
-      Moob.warn "iDRAC recommends you should change the default credentials!"
+      Moob.inform "iDRAC recommends you should change the default credentials!"
     end
 
     Moob.inform "Requesting indexurl of #{@indexurl}"

--- a/lib/moob/idrac8.rb
+++ b/lib/moob/idrac8.rb
@@ -63,7 +63,7 @@ class Idrac8 < BaseLom
 
     if @indexurl =~ /defaultCred/
       @indexurl.gsub!(/defaultCred/,'index')
-      Moob.warn "iDRAC recommends you should change the default credentials!"
+      Moob.inform "iDRAC recommends you should change the default credentials!"
     end
 
     Moob.inform "Requesting indexurl of #{@indexurl}"


### PR DESCRIPTION
To make "regular moob operations" less noisy when not using -v. I know perfectly well I'm using the default password, thank you.