### PR TITLE
Fix login and screenshot functionality for iDRAC7/8

### DIFF
--- a/lib/moob.rb
+++ b/lib/moob.rb
@@ -82,8 +82,8 @@ module Moob
   def self.save_console_preview lom
     imgfile, headers = lom.fetch_console_preview
 
-    timestamp=Time.parse(headers['Last-modified'])
-    fileext=headers['Content-type'].split('/')[1]
+    timestamp=Time.parse(headers['Last-modified'] || headers['Last-Modified'])
+    fileext=(headers['Content-type'] || headers['Content-Type']).split('/')[1]
 
     filename="#{lom.hostname}-#{timestamp.utc.iso8601(0)}.#{fileext}"
 

--- a/lib/moob/idrac6.rb
+++ b/lib/moob/idrac6.rb
@@ -188,7 +188,9 @@ class Idrac6 < BaseLom
     req = @session.get_file "capconsole/scapture0.png?#{Time.now.utc.to_i}", imgfile.path
 
     raise ResponseError.new req unless req.status == 200
-    raise UnexpectedContentError.new req unless req.headers['Content-type'] =~ /image\//
+
+    content_type = req.headers['Content-type'] || req.headers['Content-Type']
+    raise "Unexpected content type #{content_type}, expected 'image/' prefix" unless content_type =~ /image\//
 
     return imgfile, req.headers
   end

--- a/lib/moob/idrac7.rb
+++ b/lib/moob/idrac7.rb
@@ -32,6 +32,8 @@ class Idrac7 < BaseLom
     @session.handle_cookies nil
     # Needed for new version of iDrac emb web server to even responde
     @session.headers['Accept-Language'] = 'en-US,en;q=0.8,sv;q=0.6'
+    # idrac7 responds with a 404 if the request is sent for html is sent without encoding headers
+    @session.headers['Accept-Encoding'] = 'gzip,deflate,sdch'
 
     login = @session.get 'login.html'
 
@@ -223,7 +225,9 @@ class Idrac7 < BaseLom
     req = @session.get_file "capconsole/scapture0.png?#{Time.now.utc.to_i}", imgfile.path
 
     raise ResponseError.new req unless req.status == 200
-    raise UnexpectedContentError.new req unless req.headers['Content-type'] =~ /image\//
+
+    content_type = req.headers['Content-type'] || req.headers['Content-Type']
+    raise "Unexpected content type #{content_type}, expected 'image/' prefix" unless content_type =~ /image\//
 
     return imgfile, req.headers
   end

--- a/lib/moob/idrac8.rb
+++ b/lib/moob/idrac8.rb
@@ -242,7 +242,9 @@ class Idrac8 < BaseLom
     req = @session.get_file "capconsole/scapture0.png?#{Time.now.utc.to_i}", imgfile.path
 
     raise ResponseError.new req unless req.status == 200
-    raise UnexpectedContentError.new req unless req.headers['Content-type'] =~ /image\//
+
+    content_type = req.headers['Content-type'] || req.headers['Content-Type']
+    raise "Unexpected content type #{content_type}, expected 'image/' prefix" unless content_type =~ /image\//
 
     return imgfile, req.headers
   end


### PR DESCRIPTION
The current code can't successfully login to an iDRAC7 host and the screenshot functionality is broken on both iDRAC7 and iDRAC8.

To fix iDRAC7 login, moob needs to send an 'Accept-Encoding' header, the same way it already does for iDRAC8.

The screenshot functionality was broken because it looked at header names in the "wrong" casing: It was looking for "Content-type", whereas iDRAC7/8 send "Content-Type". I fixed this by looking for either casing for headers.

NOTE: This work was done at Jane Street Capital (github.com/janestreet).