### PR TITLE
Fix jnpl for ASROCK BMCs

### DIFF
--- a/lib/moob/megatrends.rb
+++ b/lib/moob/megatrends.rb
@@ -39,7 +39,7 @@ class Megatrends < BaseLom
   action :jnlp, 'Remote control'
   def jnlp
     @session.ignore_content_length = true
-    viewer = @session.get 'Java/jviewer.jnlp', { 'Cookie' => @cookie }
+    viewer = @session.get "Java/jviewer.jnlp?EXTRNIP=#{@ip}&JNLPSTR=JViewer", { 'Cookie' => @cookie }
     raise ResponseError.new viewer unless viewer.status == 200
 
     return viewer.body


### PR DESCRIPTION
This fixes RuntimeError (Invalid JNLP file) on ASROCK Rack Mainboards (eg. C2550D4I). Parameter EXTRNIP is required in order for the BMC to generate a valid JNLP.
